### PR TITLE
Tag & section filtering

### DIFF
--- a/src/main/scala/com/gu/contentapi/porter/graphql/ContentQuery.scala
+++ b/src/main/scala/com/gu/contentapi/porter/graphql/ContentQuery.scala
@@ -53,7 +53,8 @@ object ContentQuery {
             case None =>
               ctx.ctx
                 .marshalledDocs(ctx arg ContentQueryParameters.QueryString, ctx arg ContentQueryParameters.QueryFields,
-                  ctx arg ContentQueryParameters.TagArg, ctx arg ContentQueryParameters.SectionArg,
+                  ctx arg ContentQueryParameters.TagArg, ctx arg ContentQueryParameters.ExcludeTagArg,
+                  ctx arg ContentQueryParameters.SectionArg, ctx arg ContentQueryParameters.ExcludeSectionArg,
                   ctx arg PaginationParameters.OrderDate, ctx arg PaginationParameters.OrderBy, ctx arg PaginationParameters.Limit, ctx arg PaginationParameters.Cursor)
           }
       ),

--- a/src/main/scala/com/gu/contentapi/porter/graphql/ContentQueryParameters.scala
+++ b/src/main/scala/com/gu/contentapi/porter/graphql/ContentQueryParameters.scala
@@ -11,8 +11,10 @@ object ContentQueryParameters {
   val ContentIdArg = Argument("id", OptionInputType(StringType), description = "get one article by ID")
   val QueryString = Argument("q", OptionInputType(StringType), description = "an Elastic Search query string to search for content")
   val QueryFields = Argument("queryFields", OptionInputType(ListInputType(StringType)), description = "fields to perform a query against. Defaults to webTitle and path.")
-  val TagArg = Argument("tagId", OptionInputType(ListInputType(StringType)), description = "look up articles associated with these tag IDs")
-  val SectionArg = Argument("sectionId", OptionInputType(ListInputType(StringType)), description = "look up articles in this section")
+  val TagArg = Argument("tags", OptionInputType(ListInputType(StringType)), description = "look up articles associated with all of these tag IDs")
+  val ExcludeTagArg = Argument("excludeTags", OptionInputType(ListInputType(StringType)), description = "don't include any articles with these tag IDs")
+  val SectionArg = Argument("sectionId", OptionInputType(ListInputType(StringType)), description = "look up articles in any of these sections")
+  val ExcludeSectionArg = Argument("excludeSections", OptionInputType(ListInputType(StringType)), description = "don't include any articles with these tag IDs")
 
-  val AllContentQueryParameters = ContentIdArg :: QueryString :: QueryFields :: TagArg :: SectionArg :: OrderBy :: OrderDate :: Cursor :: Limit :: Nil
+  val AllContentQueryParameters = ContentIdArg :: QueryString :: QueryFields :: TagArg :: ExcludeTagArg :: SectionArg :: ExcludeSectionArg :: OrderBy :: OrderDate :: Cursor :: Limit :: Nil
 }

--- a/src/main/scala/com/gu/contentapi/porter/graphql/PaginationParameters.scala
+++ b/src/main/scala/com/gu/contentapi/porter/graphql/PaginationParameters.scala
@@ -2,8 +2,8 @@ package com.gu.contentapi.porter.graphql
 
 import sangria.schema._
 object PaginationParameters {
-  val OrderBy = Argument("orderBy", OptionInputType(anotherschema.query.OrderBy.definition), description = "how to sort the results")
-  val OrderDate = Argument("orderDate", OptionInputType(anotherschema.query.OrderDate.definition), description = "field to use for sorting the results")
+  val OrderBy = Argument("orderBy", OptionInputType(anotherschema.query.OrderBy.definition), description = "whether to order ascending or descending")
+  val OrderDate = Argument("orderDate", OptionInputType(anotherschema.query.OrderDate.definition), description = "choose a field to sort the results on")
   val Cursor = Argument("cursor", OptionInputType(StringType), description = "To continue a search, pass the value from `endCursor` in this argument")
   val Limit = Argument("limit", OptionInputType(IntType), description = "The maximum number of results to return")
 

--- a/src/main/scala/datastore/DocumentRepo.scala
+++ b/src/main/scala/datastore/DocumentRepo.scala
@@ -13,7 +13,11 @@ trait DocumentRepo {
   def docById(id:String):Future[Edge[Json]]
   def docsByWebTitle(webTitle:String, orderDate:Option[String], orderBy:Option[SortOrder], limit:Option[Int], cursor:Option[String]):Future[Edge[Json]]
 
-  def marshalledDocs(queryString: Option[String], queryFields: Option[Seq[String]], tagIds: Option[Seq[String]], sectionIds: Option[Seq[String]], orderDate:Option[String], orderBy:Option[SortOrder], limit: Option[Int], cursor: Option[String]): Future[Edge[Content]]
+  def marshalledDocs(queryString: Option[String], queryFields: Option[Seq[String]],
+                     tagIds: Option[Seq[String]], excludeTags: Option[Seq[String]],
+                     sectionIds: Option[Seq[String]], excludeSections: Option[Seq[String]],
+                     orderDate:Option[String], orderBy:Option[SortOrder],
+                     limit: Option[Int], cursor: Option[String]): Future[Edge[Content]]
 
   def marshalledTags(maybeTagId:Option[String], maybeSection: Option[String], tagType:Option[String], orderBy: Option[SortOrder], limit: Option[Int], cursor: Option[String]): Future[Edge[Tag]]
 


### PR DESCRIPTION
## What does this change?

- Drops the `webTitle` search param
- Adds a `q` (querystring) search param to match "real" concierge
- Adds a `tags` search param to specify a list of tags which must _all_ match
- Adds an `excludeTags` search param to specify a list of tags of which _none_ must match
- Adds a `sectionId` search param to specify a list of sections of which _any_ can match
- Adds an `excludeSections` search param to specify a list of sections of which _none_ must match

## How to test

Load it up as per the instructions and give them a whirl. Report any issues with your search results!

## How can we measure success?

Closer match to the existing Concierge search capabilities

## Images

<img width="1175" alt="Screenshot 2023-07-06 at 15 31 08" src="https://github.com/guardian/concierge-graphql/assets/12482441/70ff7826-3741-450a-aaef-2705db5d2b53">
