### PR TITLE
Ag/more tag params

### DIFF
--- a/src/main/scala/com/gu/contentapi/porter/graphql/Content.scala
+++ b/src/main/scala/com/gu/contentapi/porter/graphql/Content.scala
@@ -147,7 +147,7 @@ object Content {
 
     ReplaceField("tags", Field("tags", OptionType(ListType(Tags.Tag)),
       arguments = TagQueryParameters.NonPaginatedTagQueryParameters,
-      resolve=ctx=> ctx.ctx.repo.tagsForList(ctx.value.tags, ctx arg TagQueryParameters.Section, ctx arg TagQueryParameters.TagType))
+      resolve=ctx=> ctx.ctx.repo.tagsForList(ctx.value.tags, ctx arg TagQueryParameters.Section, ctx arg TagQueryParameters.TagType, ctx arg TagQueryParameters.Category, ctx arg TagQueryParameters.Reference))
     ),
     ExcludeFields("atomIds", "isGone", "isExpired", "sectionId"),
     AddFields(

--- a/src/main/scala/com/gu/contentapi/porter/graphql/ContentQueryParameters.scala
+++ b/src/main/scala/com/gu/contentapi/porter/graphql/ContentQueryParameters.scala
@@ -11,7 +11,7 @@ object ContentQueryParameters {
   val ContentIdArg = Argument("id", OptionInputType(StringType), description = "get one article by ID")
   val QueryString = Argument("q", OptionInputType(StringType), description = "an Elastic Search query string to search for content")
   val QueryFields = Argument("queryFields", OptionInputType(ListInputType(StringType)), description = "fields to perform a query against. Defaults to webTitle and path.")
-  val TagArg = Argument("tags", OptionInputType(ListInputType(StringType)), description = "look up articles associated with all of these tag IDs")
+  val TagArg = Argument("tags", OptionInputType(ListInputType(StringType)), description = "look up articles associated with all of these tag IDs. If you don't have exact tag IDs you should instead make a root query on Tags and use the `matchingContent` or `matchingAnyTag` selectors")
   val ExcludeTagArg = Argument("excludeTags", OptionInputType(ListInputType(StringType)), description = "don't include any articles with these tag IDs")
   val SectionArg = Argument("sectionId", OptionInputType(ListInputType(StringType)), description = "look up articles in any of these sections")
   val ExcludeSectionArg = Argument("excludeSections", OptionInputType(ListInputType(StringType)), description = "don't include any articles with these tag IDs")

--- a/src/main/scala/com/gu/contentapi/porter/graphql/Edge.scala
+++ b/src/main/scala/com/gu/contentapi/porter/graphql/Edge.scala
@@ -9,11 +9,11 @@ import java.nio.charset.StandardCharsets
 import java.util.Base64
 import scala.util.Try
 import io.circe.syntax._
-@deprecated("you should be using com.gu.contentapi.porter.graphql")
+
 case class Edge[T:io.circe.Decoder](totalCount:Long, endCursor:Option[String], hasNextPage:Boolean, nodes:Seq[T]) {
   def map[V:io.circe.Decoder](mapper:(T)=>V) = Edge[V](totalCount, endCursor, hasNextPage, nodes.map(mapper))
 }
-@deprecated("you should be using com.gu.contentapi.porter.graphql")
+
 object Edge {
   private val logger = LoggerFactory.getLogger(getClass)
   private val encoder = Base64.getEncoder

--- a/src/main/scala/com/gu/contentapi/porter/graphql/PaginationParameters.scala
+++ b/src/main/scala/com/gu/contentapi/porter/graphql/PaginationParameters.scala
@@ -17,8 +17,9 @@ object PaginationParameters {
   object OrderDateSchema {
     val definition = EnumType(
       "OrderDate",
-      Some("Which date field to use for ordering the content"),
+      Some("Which date field to use for ordering the content, or whether to search on document score"),
       List(
+        EnumValue("score", Some("Ignore when the content was made or published and sort by relevance to the query parameters"), "score"),
         EnumValue("published", Some("When the content was published to web"), "webPublicationDate"),
         EnumValue("firstPublished", Some("When the first version of this content was published"), "fields.firstPublicationDate"),
         EnumValue("lastModified", Some("The last time the content was modified prior to publication"), "fields.lastModified"),

--- a/src/main/scala/com/gu/contentapi/porter/graphql/RootQuery.scala
+++ b/src/main/scala/com/gu/contentapi/porter/graphql/RootQuery.scala
@@ -86,6 +86,8 @@ object RootQuery {
   val Query = ObjectType[GQLQueryContext, Unit](
     "Query", fields[GQLQueryContext, Unit](
       Field("article", ArticleEdge,
+        description = Some("An Article is the main unit of our publication.  You can search articles directly here, or query" +
+          " tags or sections to see what articles live within it."),
         arguments = ContentQueryParameters.AllContentQueryParameters,
         resolve = ctx =>
           ctx arg ContentQueryParameters.ContentIdArg match {
@@ -101,6 +103,8 @@ object RootQuery {
           }
       ),
       Field("tag", TagEdge,
+        description = Some("The Guardian uses tags to group similar pieces of content together across multiple different viewpoints.  " +
+          "Tags are a closed set, which can be searched here, and there are different types of tags which represent different viewpoints"),
         arguments = TagQueryParameters.AllTagQueryParameters,
         resolve = ctx =>
           ctx.ctx.repo.marshalledTags(ctx arg TagQueryParameters.QueryString,
@@ -114,6 +118,8 @@ object RootQuery {
             ctx arg PaginationParameters.Limit, ctx arg PaginationParameters.Cursor)
       ),
       Field("atom", AtomEdge,
+        description = Some("An Atom is a piece of content which can be linked to multiple articles but may have a production lifecycle independent" +
+          " of these articles.  Examples are cartoons, videos, quizzes, call-to-action blocks, etc."),
         arguments = AtomQueryParameters.AllParameters,
         resolve = ctx=>
       ctx.ctx.repo.atoms(ctx arg AtomQueryParameters.AtomIds, ctx arg AtomQueryParameters.QueryString, ctx arg AtomQueryParameters.QueryFields,

--- a/src/main/scala/com/gu/contentapi/porter/graphql/RootQuery.scala
+++ b/src/main/scala/com/gu/contentapi/porter/graphql/RootQuery.scala
@@ -33,7 +33,7 @@ object RootQuery {
       Field("endCursor", OptionType(StringType), Some("The last record cursor in the set"), resolve = _.value.endCursor),
       Field("hasNextPage", BooleanType, Some("Whether there are any more records to retrieve"), resolve = _.value.hasNextPage),
       Field("nodes", ListType(com.gu.contentapi.porter.graphql.Tags.Tag), Some("The actual tags returned"), resolve = _.value.nodes),
-      Field("matching_content", ArticleEdge, Some("Content which matches any of the tags returned"),
+      Field("matchingAnyTag", ArticleEdge, Some("Content which matches any of the tags returned"),
         arguments= ContentQueryParameters.AllContentQueryParameters,
         resolve = { ctx=>
          ctx.ctx.repo.marshalledDocs(ctx arg ContentQueryParameters.QueryString,

--- a/src/main/scala/com/gu/contentapi/porter/graphql/RootQuery.scala
+++ b/src/main/scala/com/gu/contentapi/porter/graphql/RootQuery.scala
@@ -74,6 +74,7 @@ object RootQuery {
         arguments = TagQueryParameters.AllTagQueryParameters,
         resolve = ctx =>
           ctx.ctx.repo.marshalledTags(ctx arg TagQueryParameters.QueryString,
+            ctx arg TagQueryParameters.Fuzziness,
             ctx arg TagQueryParameters.tagId,
             ctx arg TagQueryParameters.Section,
             ctx arg TagQueryParameters.TagType,

--- a/src/main/scala/com/gu/contentapi/porter/graphql/RootQuery.scala
+++ b/src/main/scala/com/gu/contentapi/porter/graphql/RootQuery.scala
@@ -73,7 +73,14 @@ object RootQuery {
       Field("tag", TagEdge,
         arguments = TagQueryParameters.AllTagQueryParameters,
         resolve = ctx =>
-          ctx.ctx.repo.marshalledTags(ctx arg TagQueryParameters.tagId, ctx arg TagQueryParameters.Section, ctx arg TagQueryParameters.TagType, ctx arg PaginationParameters.OrderBy, ctx arg PaginationParameters.Limit, ctx arg PaginationParameters.Cursor)
+          ctx.ctx.repo.marshalledTags(ctx arg TagQueryParameters.QueryString,
+            ctx arg TagQueryParameters.tagId,
+            ctx arg TagQueryParameters.Section,
+            ctx arg TagQueryParameters.TagType,
+            ctx arg TagQueryParameters.Category,
+            ctx arg TagQueryParameters.Reference,
+            ctx arg PaginationParameters.OrderBy,
+            ctx arg PaginationParameters.Limit, ctx arg PaginationParameters.Cursor)
       ),
       Field("atom", AtomEdge,
         arguments = AtomQueryParameters.AllParameters,

--- a/src/main/scala/com/gu/contentapi/porter/graphql/TagQueryParameters.scala
+++ b/src/main/scala/com/gu/contentapi/porter/graphql/TagQueryParameters.scala
@@ -96,13 +96,29 @@ object TagQueryParameters {
     )
   )
 
+  val FuzzinessOptions = EnumType(
+    "FuzzinessOptions",
+    Some("Valid options for making a fuzzy-match query"),
+    List(
+      EnumValue("AUTO",
+        value="AUTO",
+        description=Some("Generates an edit distance based on the length of the term. If the term is >5 chars, then 2 edits allowed; if <3 chars than no edits allowed")
+      ),
+      EnumValue("OFF",
+        value="OFF",
+        description=Some("Disable fuzzy-matching")
+      )
+    )
+  )
+
   val tagId = Argument("tagId", OptionInputType(StringType), description = "Retrieve this specific tag")
   val Section = Argument("section", OptionInputType(StringType), description = "Only return tags from this section")
   val TagType = Argument("type", OptionInputType(TagTypes), description = "Type of the tag to return")
-  val QueryString = Argument("q", OptionInputType(StringType), description = "Generic Lucene query string for finding tags")
+  val QueryString = Argument("q", OptionInputType(StringType), description = "Search for tags that match this public-facing name")
+  val Fuzziness = Argument("fuzzy", OptionInputType(FuzzinessOptions), description = "Perform a fuzzy-matching query (default). Set to `OFF` to disable fuzzy-matching.")
   val Category = Argument("category", OptionInputType(StringType), description = "A category to match against tags")
   val Reference = Argument("reference", OptionInputType(StringType), description = "A reference to match against tags")
-  val AllTagQueryParameters = QueryString :: tagId :: Section :: TagType :: Category ::
+  val AllTagQueryParameters = QueryString :: tagId :: Section :: TagType :: Fuzziness :: Category ::
     Reference :: Cursor :: OrderBy :: Limit :: Nil
 
   val NonPaginatedTagQueryParameters = Section :: TagType :: Nil

--- a/src/main/scala/com/gu/contentapi/porter/graphql/TagQueryParameters.scala
+++ b/src/main/scala/com/gu/contentapi/porter/graphql/TagQueryParameters.scala
@@ -99,7 +99,11 @@ object TagQueryParameters {
   val tagId = Argument("tagId", OptionInputType(StringType), description = "Retrieve this specific tag")
   val Section = Argument("section", OptionInputType(StringType), description = "Only return tags from this section")
   val TagType = Argument("type", OptionInputType(TagTypes), description = "Type of the tag to return")
-  val AllTagQueryParameters = tagId :: Section :: TagType :: Cursor :: OrderBy :: Limit :: Nil
+  val QueryString = Argument("q", OptionInputType(StringType), description = "Generic Lucene query string for finding tags")
+  val Category = Argument("category", OptionInputType(StringType), description = "A category to match against tags")
+  val Reference = Argument("reference", OptionInputType(StringType), description = "A reference to match against tags")
+  val AllTagQueryParameters = QueryString :: tagId :: Section :: TagType :: Category ::
+    Reference :: Cursor :: OrderBy :: Limit :: Nil
 
   val NonPaginatedTagQueryParameters = Section :: TagType :: Nil
 }

--- a/src/main/scala/com/gu/contentapi/porter/graphql/TagQueryParameters.scala
+++ b/src/main/scala/com/gu/contentapi/porter/graphql/TagQueryParameters.scala
@@ -121,5 +121,6 @@ object TagQueryParameters {
   val AllTagQueryParameters = QueryString :: tagId :: Section :: TagType :: Fuzziness :: Category ::
     Reference :: Cursor :: OrderBy :: Limit :: Nil
 
-  val NonPaginatedTagQueryParameters = Section :: TagType :: Nil
+  val NonPaginatedTagQueryParameters = QueryString :: tagId :: Section :: TagType :: Fuzziness :: Category ::
+    Reference :: Nil
 }

--- a/src/main/scala/com/gu/contentapi/porter/graphql/Tags.scala
+++ b/src/main/scala/com/gu/contentapi/porter/graphql/Tags.scala
@@ -7,6 +7,7 @@ import java.time.format.DateTimeFormatter
 import io.circe.generic.auto._
 import io.circe.syntax._
 import com.gu.contentapi.porter.model
+import datastore.GQLQueryContext
 
 object Tags {
   import Content.Reference
@@ -15,10 +16,30 @@ object Tags {
   implicit val PodcastCategory = deriveObjectType[Unit, model.PodcastCategory]()
   implicit val TagPodcast = deriveObjectType[Unit, model.TagPodcast]()
 
-  val Tag = deriveObjectType[Unit, model.Tag](
+  val Tag = deriveObjectType[GQLQueryContext, model.Tag](
     ReplaceField("type", Field("type", OptionType(TagQueryParameters.TagTypes), resolve=_.value.`type`)),
-    ReplaceField("alternateIds", Field("alternateIds", ListType(StringType), arguments = AlternateIdParameters.AllAlternateIdParameters, resolve= AlternateIdParameters.TagResolver[Unit])),
+    ReplaceField("alternateIds", Field("alternateIds", ListType(StringType), arguments = AlternateIdParameters.AllAlternateIdParameters, resolve= AlternateIdParameters.TagResolver[GQLQueryContext])),
     ReplaceField("tagCategories", Field("tagCategories", ListType(StringType), resolve = _.value.tagCategories.map(_.toSeq).getOrElse(Seq()))),
-    ReplaceField("entityIds", Field("entityIds", ListType(StringType), resolve = _.value.tagCategories.map(_.toSeq).getOrElse(Seq())))
+    ReplaceField("entityIds", Field("entityIds", ListType(StringType), resolve = _.value.tagCategories.map(_.toSeq).getOrElse(Seq()))),
+    AddFields(
+      Field("matchingContent", RootQuery.ArticleEdge, description=Some("Articles and other content which have this tag"),
+        arguments= ContentQueryParameters.AllContentQueryParameters.filterNot(_ == ContentQueryParameters.TagArg),
+        resolve = { ctx=>
+          ctx.ctx.repo.marshalledDocs(ctx arg ContentQueryParameters.QueryString,
+            queryFields=ctx arg ContentQueryParameters.QueryFields,
+            atomId = None,
+            forChannel = ctx arg ContentQueryParameters.ChannelArg,
+            userTier = ctx.ctx.userTier,
+            tagIds = Some(Seq(ctx.value.id)),
+            excludeTags = ctx arg ContentQueryParameters.ExcludeTagArg,
+            sectionIds = ctx arg ContentQueryParameters.SectionArg,
+            excludeSections = ctx arg ContentQueryParameters.ExcludeSectionArg,
+            orderDate = ctx arg PaginationParameters.OrderDate,
+            orderBy = ctx arg PaginationParameters.OrderBy,
+            limit = ctx arg PaginationParameters.Limit,
+            cursor = ctx arg PaginationParameters.Cursor,
+          )
+        })
+    )
   )
 }

--- a/src/main/scala/datastore/DocumentRepo.scala
+++ b/src/main/scala/datastore/DocumentRepo.scala
@@ -20,10 +20,17 @@ trait DocumentRepo {
                      orderDate:Option[String], orderBy:Option[SortOrder],
                      limit: Option[Int], cursor: Option[String]): Future[Edge[Content]]
 
-  def marshalledTags(maybeTagId:Option[String], maybeSection: Option[String], tagType:Option[String],
-                     orderBy: Option[SortOrder], limit: Option[Int], cursor: Option[String]): Future[Edge[Tag]]
+  def marshalledTags(maybeQuery:Option[String],
+                     maybeTagId:Option[String],
+                     maybeSection: Option[String],
+                     tagType:Option[String],
+                     maybeCategory:Option[String],
+                     maybeReferences:Option[String],
+                     orderBy: Option[SortOrder],
+                     limit: Option[Int],
+                     cursor: Option[String]): Future[Edge[Tag]]
 
-  def tagsForList(tagIdList:Seq[String], maybeSection: Option[String], tagType:Option[String]):Future[Seq[Tag]]
+  def tagsForList(tagIdList:Seq[String], maybeSection: Option[String], tagType:Option[String], maybeCategory:Option[String], maybeReferences:Option[String]):Future[Seq[Tag]]
 
   def atomsForList(atomIds: Seq[String], atomType: Option[String]):Future[Seq[Json]]
 

--- a/src/main/scala/datastore/DocumentRepo.scala
+++ b/src/main/scala/datastore/DocumentRepo.scala
@@ -21,6 +21,7 @@ trait DocumentRepo {
                      limit: Option[Int], cursor: Option[String]): Future[Edge[Content]]
 
   def marshalledTags(maybeQuery:Option[String],
+                     maybeFuzziness:Option[String],
                      maybeTagId:Option[String],
                      maybeSection: Option[String],
                      tagType:Option[String],

--- a/src/main/scala/datastore/ElasticsearchRepo.scala
+++ b/src/main/scala/datastore/ElasticsearchRepo.scala
@@ -73,8 +73,9 @@ class ElasticsearchRepo(endpoint:ElasticNodeEndpoint, val defaultPageSize:Int=20
 
   private def defaultingSortParam(orderDate:Option[String], orderBy:Option[SortOrder]): Sort = {
     orderDate match {
+      case Some("score")=>ScoreSort(orderBy.getOrElse(SortOrder.DESC))
       case Some(field)=>FieldSort(field, order = orderBy.getOrElse(SortOrder.DESC))
-      case None=>ScoreSort(orderBy.getOrElse(SortOrder.DESC))
+      case None=>FieldSort("webPublicationDate", order=orderBy.getOrElse(SortOrder.DESC))
     }
   }
 

--- a/src/main/scala/datastore/ElasticsearchRepo.scala
+++ b/src/main/scala/datastore/ElasticsearchRepo.scala
@@ -163,7 +163,7 @@ class ElasticsearchRepo(endpoint:ElasticNodeEndpoint, val defaultPageSize:Int=20
       Some(limitToChannelQuery(selectedChannel)),
       queryString.map(MultiMatchQuery(_, fields = fieldsToQuery)),
       atomId.map(MatchQuery("atomIds.id", _)),
-      tagIds.map(tags=>BoolQuery(must=tags.map(MatchQuery("tags", _)))) ,
+      tagIds.map(tags=>BoolQuery(should=tags.map(MatchQuery("tags", _)))) ,
       excludeTags.map(tags=>BoolQuery(not=Seq(BoolQuery(should=tags.map(MatchQuery("tags", _)))))),
       sectionIds.map(s=>BoolQuery(should=s.map(MatchQuery("sectionId", _)))),
       excludeSections.map(s=>BoolQuery(not=Seq(BoolQuery(should=s.map(MatchQuery("sectionId", _))))))


### PR DESCRIPTION
## What does this change?

Adds some more tag search parameters, hopefully to help Ask Guardian! 🤞 

- Fuzzy-matching on the tag name
- Matching on tag categories and references
- Return of matching documents in a sub-query on tags

## How to test

- Deploy to CODE
- Fire it up on https://graphiql.capi.code.dev-gutools.co.uk/
- Make sure you refresh the schema
- Build a tag query like this: (note the deliberate mis-spelling of "football")

```graphql
{
	tag(q:"footbowl",type:keyword,limit:5) {
    totalCount
    endCursor
    nodes {
      webTitle
      id
      internalName
    }
    matching_content(limit:10, orderDate:published, orderBy:newest, excludeTags:["politics/politics"]) {
      totalCount
      endCursor
      nodes {
        id
        webTitle
        keywords:tags(type:keyword) {
          id
        }
      }
    }
  }
}
```

You should get matching tags for Football, `katine/football`, Women's Football, Fantasy Football....

Also, you should get a ton of hits in `matching_content` which can be paginated through by taking the `endCursor` value and putting it into a `cursor:` parameter in the `matchingContent` query.

- Have a play with the different options

## To Do

- [x] Fix cursor pagination for tags
- [x] Add a selector for content matching each single tag (on the `Tag` object)

## How can we measure success?

Another way of exploring Guardian content

## Have we considered potential risks?

Keep an eye on query complexity
